### PR TITLE
form for admin settings and variable checking logic in mail

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -1,0 +1,17 @@
+# Configuration email notices
+
+Tripal HQ is configured to notify both users and administrators when the following events occur for a given requested record:
+
+* Creation
+* Edit
+* Approval
+* Rejection
+
+## Setting and unsetting notifications
+
+
+## Users opting out of notices
+Coming soon
+
+## Customizing messages
+Coming soon

--- a/includes/tripal_hq_admin_settings.form.inc
+++ b/includes/tripal_hq_admin_settings.form.inc
@@ -3,7 +3,60 @@
 
 function tripal_hq_admin_settings_form($form, &$form_state) {
 
-  $form['instructions'] = ['#markup' => "Hi mom.  Site-wide settings here.  configure which emails go out."];
+  ///Use previous form settings.  If new form, then use saved site variables.
+  $prev_email = isset($form_state['values']['email']) ? $form_state['values']['email'] : tripal_hq_get_email_settings();
+
+  $form['instructions'] = ['#markup' => "<p>The below form will let you configure site-wide preferences for this module.</p>"];
+
+
+  $form['email'] = [
+    '#type' => "fieldset",
+    '#title' => t('Email Notification Settings'),
+    '#tree' => TRUE,
+  ];
+
+  $form['email']['submit_request'] = [
+    '#type' => "checkboxes",
+    '#title' => t('Content Creation Request'),
+    '#multiple' => TRUE,
+    '#options' => ['User' => t('User'), 'Admin' => t('Admin')],
+    '#description' => t('When a user submits a new content creation request, an email can be sent to confirm creation to the user, and to notify the admin an action is required.'),
+    '#default_value' => $prev_email['submit_request'] ? $prev_email['submit_request'] : [],
+  ];
+
+
+  $form['email']['edit_request'] = [
+    '#type' => 'checkboxes',
+    '#multiple' => TRUE,
+    '#title' => t('Content Creation Request Edit'),
+    '#options' => ['User' => t('User'), 'Admin' => t('Admin')],
+    '#description' => t('When a user edits an existing content creation request, an email can be sent to confirm creation to the user, and to notify the admin an action is required.'),
+    '#default_value' => $prev_email['edit_request'] ? $prev_email['edit_request'] : [],
+
+  ];
+
+
+  $form['email']['approval'] = [
+    '#type' => 'checkboxes',
+    '#multiple' => TRUE,
+    '#title' => t('Content Creation Request Approved'),
+    '#options' => ['User' => t('User'), 'Admin' => t('Admin')],
+    '#description' => t('When an admin approves a creation request, an email can be sent to notify the user and/or admin.'),
+    '#default_value' => $prev_email['approval'] ? $prev_email['approval'] : [],
+
+  ];
+
+
+  $form['email']['denied'] = [
+    '#type' => 'checkboxes',
+    '#multiple' => TRUE,
+    '#title' => t('Content Creation Request Denied'),
+    '#options' => ['User' => t('User'), 'Admin' => t('Admin')],
+    '#description' => t('When an admin rejects a creation request, an email can be sent to notify the user and/or admin.'),
+    '#default_value' => $prev_email['denied'] ? $prev_email['denied'] : [],
+  ];
+
+  $form['submit'] = ['#type' => 'submit', '#value' => 'Submit'];
 
   return $form;
 
@@ -13,8 +66,49 @@ function tripal_hq_admin_settings_form_validate() {
 
 }
 
-function tripal_hq_admin_settings_form_submit() {
+/**
+ * Implements hook_form_submit().
+ *
+ * @see tripal_hq_mail for mail keys.
+ */
+function tripal_hq_admin_settings_form_submit($form, &$form_state) {
 
+
+  $values = $form_state['values'];
+  $email_prefs = $values['email'];
+
+  foreach ($email_prefs as $key => $values) {
+    $global_key = 'tripal_hq_' . $key;
+    variable_set($global_key, $values);
+  }
+
+  tripal_set_message('Tripal HQ module settings changed', TRIPAL_NOTICE);
 }
 
 
+/**
+ * Get all set variables for tripal_hq.
+ * As of now that is just email settings.
+ *
+ * @return array
+ */
+function tripal_hq_get_email_settings() {
+
+  $keys = [
+    "submit_request",
+    "edit_request",
+    "approval",
+    "denied",
+  ];
+
+  $vals = [];
+
+  foreach ($keys as $key) {
+
+    $search_key = 'tripal_hq_' . $key;
+
+    $value = variable_get($search_key);
+    $vals[$key] = $value;
+  }
+  return $vals;
+}

--- a/includes/tripal_hq_email.inc
+++ b/includes/tripal_hq_email.inc
@@ -3,10 +3,81 @@
 
 /**
  * Implements hook_mail().
+ *
  * @param $key
+ *    One of the following strings:
+ *      - user_submit_notice
+ *      - admin_submit_notice
+ *      - user_accept_notice
+ *      - admin_accept_notice
+ *      - user_reject_notice
+ *      - admin_reject_notice
+ *      - user_edit_notice
+ *      - admin_edit_notice
+ *
  * @param $message
- * @param $params
+ * @param $params - assumes the following keys exist:
+ *      - user_name
+ *
  */
-function tripal_chado_datasets_mail($key, &$message, $params) {
+function tripal_hq_mail($key, &$message, $params) {
+  $language = $message['language'];
+  $site_name = variable_get('site_name');
+  $site_email = variable_get('site_mail');
+  $user = $params['user_name'];
 
+  switch ($key) {
+
+    /**
+     * Acknowledge user has submitted a content request.
+     */
+    case 'user_submit_notice':
+      $site_settings = variable_get('tripal_submit_request');
+      if ($site_settings['User'] == 0) {
+        return;
+      }
+      $message['body'][] = t("Dear !user,", ['!user' => $user]);
+      $message['subject'] = t('!site Content Submission Request Received', ['!site' => $site_name], ['langcode' => $language->language]);
+
+      break;
+
+    /**
+     * Let relevant admins know a content request has been received.
+     */
+    case 'admin_submit_notice':
+      $site_settings = variable_get('tripal_submit_request');
+      if ($site_settings['Admin'] == 0) {
+        return;
+      }
+      //TODO: flesh this out.
+      $message['subject'] = t('!site Content Submission Request Received', ['!site' => $site_name], ['langcode' => $language->language]);
+      $message['body'][] = t("Dear !user,", ['!user' => $user]);
+      $message['body'][] = t("A user has submitted the following content creation request:");
+      $message['body'][] = t("To approve or deny this request, please visit your Tripal HQ content portal, located here:");
+
+      break;
+
+    /**
+     * User's submission has been approved!
+     */
+    case 'user_accept_notice':
+
+      //TODO: flesh this out.
+
+
+      break;
+
+    /**
+     * Admin: submission has been approved!
+     */
+    case 'admin_accept_notice':
+
+      //TODO: flesh this out.
+
+
+      break;
+  }
+
+  $message['body'][] = '<br><BR>Regards,<br><bR>The ' . $site_name . 'team';
+  $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
 }


### PR DESCRIPTION
Site wide admin email settings:
![screen shot 2018-10-10 at 1 46 50 pm](https://user-images.githubusercontent.com/7063154/46755401-f99e6900-cc92-11e8-818b-d595eda13300.png)

I stub out the emails and show how we will fetch the variable to see if we send an email in this case.

Remaining is to execute `drupal_mail` with the needed parameters upon content creation, editing, approval, and rejection.