### PR TITLE
rename update version

### DIFF
--- a/tripal_hq.install
+++ b/tripal_hq.install
@@ -89,7 +89,7 @@ function tripal_hq_uninstall() {
 /**
  * Add nid column to tripal_hq_submission table.
  */
-function tripal_hq_update_2100() {
+function tripal_hq_update_7100() {
   if (!db_field_exists('tripal_hq_submission', 'nid')) {
     db_add_field(
       'tripal_hq_submission', 'nid', [


### PR DESCRIPTION
renames update version to 7100.

i personally like starting at 7.x-3.x to indicate this vrsion is compatible with Tripal 3.  However that brings its own confusion in that it implies the existince of a 7.x-1 and 2.  

Given its much easier to increase the version than decrease, we're doing this for now.